### PR TITLE
Fix bug where adding an intermediate word after an existing word does…

### DIFF
--- a/lib/complete_me.rb
+++ b/lib/complete_me.rb
@@ -7,6 +7,7 @@ class CompleteMe
 
   class Node
     attr_reader :letter, :children
+    attr_writer :valid
     attr_accessor :word, :search_selections
     def initialize(letter=nil, valid_word=false)
       @letter = letter
@@ -15,7 +16,7 @@ class CompleteMe
     end
 
     def to_s
-      "Node: #{word}, #{@letter ? @letter : "nil"}, #{@children}, #{@valid}, #{self.search_selections}"
+      "Node: word: #{word ? word : "nil"}, #{@letter ? @letter : "nil"}, #{@children}, #{@valid}, #{self.search_selections}"
     end
 
     def valid?
@@ -37,7 +38,13 @@ class CompleteMe
             # if this node is in children, don't add a new one, but call add_child
             return child_node.add_child(letters, begin_index + 1)
           else
-            return false
+            if(child_node.valid?)
+              return false
+            else
+              child_node.valid = true
+              child_node.word = letters.join
+              return true
+            end
           end
         else
           # add this letter node as a child
@@ -85,32 +92,11 @@ class CompleteMe
         suggest_words(node, word, suggestions)
       end
     end
-    # sort suggestions by the number of times word has been selected
-    suggestions.sort! do |a, b|
-      a_selections = a.search_selections
-      b_selections = b.search_selections
-      a_num = 0
-      b_num = 0
-      if(a_selections)
-        temp = a_selections[word]
-        if(temp)
-          a_num = temp
-        end
-      end
-      if(b_selections)
-        temp = b_selections[word]
-        if(temp)
-          b_num = temp
-        end
-      end
-      # this is a reverse sort
-      b_num - a_num
-    end
+    sorted = sort_suggestions(word, suggestions)
 
-    suggestions.map do |n|
+    sorted.map do |n|
       n.word
     end
-
   end
 
   def select(input, word)
@@ -141,6 +127,30 @@ class CompleteMe
         end
         suggest_words(child, new_word, nodes_array)
       end
+    end
+  end
+
+  def sort_suggestions(word, suggestions)
+    # sort suggestions by the number of times word has been selected
+    suggestions.sort do |a, b|
+      a_selections = a.search_selections
+      b_selections = b.search_selections
+      a_num = 0
+      b_num = 0
+      if(a_selections)
+        temp = a_selections[word]
+        if(temp)
+          a_num = temp
+        end
+      end
+      if(b_selections)
+        temp = b_selections[word]
+        if(temp)
+          b_num = temp
+        end
+      end
+      # this is a reverse sort
+      b_num - a_num
     end
   end
 

--- a/test/complete_me_test.rb
+++ b/test/complete_me_test.rb
@@ -44,6 +44,14 @@ class CompleteMeTest < Minitest::Test
     assert_equal 1, complete_me.count
   end
 
+  def test_it_inserts_sub_words_and_updates_word_count
+    complete_me = CompleteMe.new
+    complete_me.insert("pizza")
+    complete_me.insert("piz")
+
+    assert_equal 2, complete_me.count
+  end
+
   def test_it_returns_no_items_when_there_are_no_suggestions
     complete_me = CompleteMe.new
     complete_me.insert("pizza")
@@ -62,15 +70,35 @@ class CompleteMeTest < Minitest::Test
 
   def test_it_can_suggest_items_in_dictionary_with_intermediate_words
     complete_me = CompleteMe.new
-    complete_me.insert("pizza")
     complete_me.insert("pizzeria")
+    complete_me.insert("pi")
     complete_me.insert("pizzazz")
+    complete_me.insert("pizza")
+    complete_me.insert("pie")
+    complete_me.insert("parts")
 
     sug = complete_me.suggest("piz")
     assert_equal ["pizza", "pizzeria", "pizzazz"].sort, sug.sort
 
+    refute sug.include?('pizzer')
+
     sug = complete_me.suggest("pizza")
-    assert_equal ["pizzazz"].sort, sug.sort
+    assert_equal ["pizzazz"], sug
+  end
+
+  def test_it_can_add_intermediate_words_and_suggest
+    complete_me = CompleteMe.new
+    complete_me.insert("pizzas")
+    complete_me.insert("pi")
+
+    sug = complete_me.suggest("piz")
+    assert_equal ["pizzas"], sug
+
+    refute sug.include?('pizza')
+
+    complete_me.insert('pizza')
+    sug = complete_me.suggest("piz")
+    assert_equal ["pizza", "pizzas"].sort, sug.sort
   end
 
   def test_it_does_not_suggest_same_word_as_in_dictionary
@@ -153,6 +181,12 @@ class CompleteMeTest < Minitest::Test
     sug = completion.suggest("pi")
     assert_equal "pizza", sug[0]
     assert_equal "pizzicato", sug[1]
+  end
+
+  def test_it_can_prune_intermediate_nodes
+    completion = CompleteMe.new
+    completion.insert('trying')
+    completion.insert('try')
   end
 
 end


### PR DESCRIPTION
… not

track intermediate word. For example,  followed by .